### PR TITLE
Handle asset scale and position

### DIFF
--- a/src/modules/marker/index.js
+++ b/src/modules/marker/index.js
@@ -39,8 +39,9 @@ export class MarkerModule {
         });
     }
 
-    static generatePatternHtml(assetType, assetPath) {
+    static generatePatternHtml(assetType, assetParam, assetPath) {
         return TEMPLATES[assetType]({
+            assetParam,
             assetPath,
         });
     }

--- a/src/modules/marker/templates/pattern.3d.handlebars
+++ b/src/modules/marker/templates/pattern.3d.handlebars
@@ -28,7 +28,7 @@
                 url="assets/marker.patt"
             >
                 <a-entity
-                    scale="{{assetParam.scale}}"
+                    scale="{{assetParam.scale}} {{assetParam.scale}} {{assetParam.scale}}"
                     animation-mixer="loop: repeat"
                     gltf-model="#animated-asset"
                 ></a-entity>

--- a/src/modules/marker/templates/pattern.3d.handlebars
+++ b/src/modules/marker/templates/pattern.3d.handlebars
@@ -28,6 +28,7 @@
                 url="assets/marker.patt"
             >
                 <a-entity
+                    scale="{{assetParam.scale}}"
                     animation-mixer="loop: repeat"
                     gltf-model="#animated-asset"
                 ></a-entity>

--- a/src/modules/marker/templates/pattern.image.handlebars
+++ b/src/modules/marker/templates/pattern.image.handlebars
@@ -18,7 +18,10 @@
                 preset="custom"
                 url="assets/marker.patt"
             >
-                <a-image src="{{assetPath}}"></a-image>
+                <a-image
+                    src="{{assetPath}}"
+                    scale="{{assetParam.scale}} {{assetParam.scale}} {{assetParam.scale}}"
+                ></a-image>
             </a-marker>
 
             <a-entity camera></a-entity>

--- a/src/modules/marker/templates/pattern.video.handlebars
+++ b/src/modules/marker/templates/pattern.video.handlebars
@@ -40,6 +40,7 @@
             >
                 <a-video
                     src="#vid"
+                    scale="{{assetParam.scale}} {{assetParam.scale}} {{assetParam.scale}}"
                     position="0 0.1 0"
                     rotation="-90 0 0"
                 ></a-video>

--- a/src/modules/package/Package.js
+++ b/src/modules/package/Package.js
@@ -18,6 +18,13 @@ export const AR_PATTERN = 'pattern';
 export const AR_LOCATION = 'location';
 export const AR_NTF = 'ntf';
 
+/**
+ * @typedef AssetParam
+ * @property {boolean} isValid
+ * @property {Number} scale
+ * @property {{width: Number, height: Number, depth: Number}} size
+ */
+
 export class Package {
     /**
      * @param {Object} config
@@ -25,6 +32,7 @@ export class Package {
      * @param {string} config.assetType - one of 3d, image, audio or video (see {@link MarkerModule} exported constants)
      * @param {string|Blob} config.assetFile - the file to be show in AR
      * @param {string} config.assetName - the file name, to be included in HTML template
+     * @param {AssetParam} config.assetParam - scale and position of AR asset
      * @param {string} [config.markerPatt] - the marker image patt file (required for pattern AR type)
      * @param {string} [config.matrixType] - the barcode matrix type (see {@link BarcodeMarkerGenerator} exported constants, required for barcode AR type)
      * @param {number} [config.markerValue] - the barcode value of the marker (required for barcode AR type)
@@ -34,6 +42,12 @@ export class Package {
         this.assetType = config.assetType;
         this.assetFile = config.assetFile;
         this.assetName = config.assetName;
+        this.assetParam = config.assetParam;
+        
+        if (!this.assetParam.isValid) {
+            throw new Error('Asset parameters are not valid');
+        }
+        
         this.config = config;
     }
 
@@ -61,7 +75,7 @@ export class Package {
                 break;
 
             case AR_PATTERN:
-                generatedHtml = MarkerModule.generatePatternHtml(this.assetType, `assets/${this.assetName}`);
+                generatedHtml = MarkerModule.generatePatternHtml(this.assetType, this.assetParam, `assets/${this.assetName}`);
 
                 if (!this.config.markerPatt) {
                     throw new Error('Pattern-based AR needs a marker.patt file');

--- a/src/modules/package/Package.js
+++ b/src/modules/package/Package.js
@@ -24,6 +24,15 @@ export const AR_NTF = 'ntf';
  * @property {Number} scale
  * @property {{width: Number, height: Number, depth: Number}} size
  */
+const defaultAssetParam = {
+    isValid: true,
+    scale: 1.0,
+    size: {
+        width: 1.0,
+        height: 1.0,
+        depth: 1.0,
+    },
+};
 
 export class Package {
     /**
@@ -32,7 +41,7 @@ export class Package {
      * @param {string} config.assetType - one of 3d, image, audio or video (see {@link MarkerModule} exported constants)
      * @param {string|Blob} config.assetFile - the file to be show in AR
      * @param {string} config.assetName - the file name, to be included in HTML template
-     * @param {AssetParam} config.assetParam - scale and position of AR asset
+     * @param {AssetParam} [config.assetParam] - scale and position of AR asset
      * @param {string} [config.markerPatt] - the marker image patt file (required for pattern AR type)
      * @param {string} [config.matrixType] - the barcode matrix type (see {@link BarcodeMarkerGenerator} exported constants, required for barcode AR type)
      * @param {number} [config.markerValue] - the barcode value of the marker (required for barcode AR type)
@@ -42,7 +51,7 @@ export class Package {
         this.assetType = config.assetType;
         this.assetFile = config.assetFile;
         this.assetName = config.assetName;
-        this.assetParam = config.assetParam;
+        this.assetParam = config.assetParam || defaultAssetParam;
         
         if (!this.assetParam.isValid) {
             throw new Error('Asset parameters are not valid');


### PR DESCRIPTION
This PR adds scale and position to HTML templates (see #27 ).

- [x] scale
- [x] position
- [x] rotation

Frontend calls `new Package({...})` with a new parameter `assetParam`, structured like this:

```
{
  isValid: <bool>,
  scale: <float>,
  size: {
    width: <float>,
    height: <float>,
    depth: <float>
  }
}
```

Currently the code uses only `scale`, I don't think `size` is to be used. We would also need to add a default position (ping @nicolocarpignoli ).