### PR TITLE
Fix endpoint to API in GitHub

### DIFF
--- a/src/providers/github.js
+++ b/src/providers/github.js
@@ -111,7 +111,7 @@ export class GithubProvider extends BaseProvider {
             return await this.getBranch(name);
         } catch (e) {
             // console.warn('branch not found, creating');
-            const masterRef = await this.getRef('master');
+            const masterRef = await this.getRef('main');
             await this.createBranch(masterRef.object.sha, name);
             return await this.getBranch(name);
         }


### PR DESCRIPTION
Default branch name in GitHub now is `main`

https://www.zdnet.com/article/github-to-replace-master-with-main-starting-next-month/